### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-.github/settings.yml @cucumber/settings


### PR DESCRIPTION
The CODEOWNERS file was an attempt to setup a fine grained permission model unfortunately GitHub does not support this model as it requires all changes to go through an pull request to be enforced. We consider this too much friction.

Additionally the requirement for a pull request prevents Renovate from pushing changes directly to main. This generates notification spam.
